### PR TITLE
small hotfix in AltChecker

### DIFF
--- a/main.js
+++ b/main.js
@@ -204,7 +204,7 @@ async function altChecker() {
         outcome.timestamp = Date.now();
         altCheck.playerData[player] = outcome;
 
-        if (outcome.possibleAlts === 0) return; //No alts was found
+        if (outcome.possibleAlts === 0) continue; //No alts was found
 
         const data = {
             steamId: core.players[player]?.steamId,


### PR DESCRIPTION
Little fix, not to return from AltChecker function when there was no alt found, just keep going with the next player